### PR TITLE
Fix README title typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Gapless superconductivity overview formular.
+# Gapless superconductivity overview formula.
 
 This document contains brief and raw overview of some aspects of the gapless superconductivity.


### PR DESCRIPTION
## Summary
- fix a typo in the README title referencing the overview formula

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684008601cc0832aa3df59d6cb5ec8a4