### PR TITLE
Fix Hamiltonian integral spacing

### DIFF
--- a/gapless_superconductivity.tex
+++ b/gapless_superconductivity.tex
@@ -134,11 +134,11 @@ Hamiltonian in terms of the field operators.
         \sigma=\uparrow,\downarrow
     }}
     \int{
-        \psi^\dagger_\sigma\left(-\frac{1}{2m}\nabla^2-\mu\right)\psi_\sigma{d^3}x
+        \psi^\dagger_\sigma\left(-\frac{1}{2m}\nabla^2-\mu\right)\psi_\sigma\, d^3 x
     }
     {\textrm{+V}}
     \int{
-        (\psi^\dagger(x)\psi(x))(\psi^\dagger(x)\psi(x)){d^3}x
+        (\psi^\dagger(x)\psi(x))(\psi^\dagger(x)\psi(x))\, d^3 x
     }
 \end{equation}
 


### PR DESCRIPTION
## Summary
- correct spacing around `d^3 x` in the Hamiltonian definition

## Testing
- `pdflatex --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840085af990832a841cc7e014032486